### PR TITLE
variable-node-state-value-rank-persistence-fix

### DIFF
--- a/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseVariableState.cs
@@ -880,7 +880,9 @@ namespace Opc.Ua
                 encoder.WriteNodeId("DataType", DataType);
             }
 
-            if (ValueRank != ValueRanks.Any)
+            int valueRank = ValueRank;
+
+            if (valueRank != ValueRanks.OneOrMoreDimensions)
             {
                 encoder.WriteInt32("ValueRank", ValueRank);
             }
@@ -1028,7 +1030,7 @@ namespace Opc.Ua
                 attributesToSave |= AttributesToSave.DataType;
             }
 
-            if (m_valueRank != ValueRanks.Any)
+            if (m_valueRank != ValueRanks.OneOrMoreDimensions)
             {
                 attributesToSave |= AttributesToSave.ValueRank;
             }

--- a/Stack/Opc.Ua.Core/Stack/State/BaseVariableTypeState.cs
+++ b/Stack/Opc.Ua.Core/Stack/State/BaseVariableTypeState.cs
@@ -256,7 +256,9 @@ namespace Opc.Ua
                 encoder.WriteNodeId("DataType", DataType);
             }
 
-            if (ValueRank != ValueRanks.Any)
+            int valueRank = ValueRank;
+
+            if (valueRank != ValueRanks.OneOrMoreDimensions)
             {
                 encoder.WriteInt32("ValueRank", ValueRank);
             }
@@ -322,7 +324,7 @@ namespace Opc.Ua
                 attributesToSave |= AttributesToSave.DataType;
             }
 
-            if (m_valueRank != ValueRanks.Any)
+            if (m_valueRank != ValueRanks.OneOrMoreDimensions)
             {
                 attributesToSave |= AttributesToSave.ValueRank;
             }


### PR DESCRIPTION
Fixed value rank persistence to only omit value rank if it is the default value of int OneOrMoreDimensions (0). Currently persistence causes value rank Any to be changed to OneOrMoreDimensions.